### PR TITLE
feat: create workflow for terraform deployment on push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:
       run:
-        working-directory: terraform
+        working-directory: infra
         shell: bash
 
     steps:
@@ -82,7 +82,6 @@ jobs:
     # Currently the only to way to pass variables is by creating a `*.auto.tfvars` variables file.
     - name: Setup Terraform variables
       id: vars
-      working-directory: ./infra
       run: |-
         cat > pipeline.auto.tfvars <<EOF
         mongodb_atlas_private_key = "${{ secrets.ATLAS_DB_PROJECT_PRIVATE_API_KEY }}"
@@ -112,7 +111,7 @@ jobs:
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:
       run:
-        working-directory: terraform
+        working-directory: infra
         shell: bash
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,9 +82,8 @@ jobs:
     # Currently the only to way to pass variables is by creating a `*.auto.tfvars` variables file.
     - name: Setup Terraform variables
       id: vars
+      working-directory: ./infra
       run: |-
-        pwd
-        ls -la
         cat > pipeline.auto.tfvars <<EOF
         mongodb_atlas_private_key = "${{ secrets.ATLAS_DB_PROJECT_PRIVATE_API_KEY }}"
         curzy_user_password       = "${{ secrets.MONGODB_USER_PASSWORD }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,146 @@
+# This workflow installs the latest version of Terraform CLI and configures the Terraform CLI configuration file
+# with an API token for Terraform Cloud (app.terraform.io). On pull request events, this workflow will run
+# `terraform init`, `terraform fmt`, and `terraform plan` (speculative plan via Terraform Cloud). On push events
+# to the "main" branch, `terraform apply` will be executed.
+#
+# Documentation for `hashicorp/setup-terraform` is located here: https://github.com/hashicorp/setup-terraform
+#
+# To use this workflow, you will need to complete the following setup steps.
+#
+# 1. Create a `main.tf` file in the `/terraform` folder with the `remote` backend and one or more resources defined.
+#   Example `main.tf`:
+#     # The configuration for the `remote` backend.
+#     terraform {
+#       backend "remote" {
+#         # The name of your Terraform Cloud organization.
+#         organization = "example-organization"
+#
+#         # The name of the Terraform Cloud workspace to store Terraform state files in.
+#         workspaces {
+#           name = "example-workspace"
+#         }
+#       }
+#     }
+#
+#     # An example resource that does nothing.
+#     resource "null_resource" "example" {
+#       triggers = {
+#         value = "A example resource that does nothing!"
+#       }
+#     }
+#
+#
+# 2. Generate a Terraform Cloud user API token and store it as a GitHub secret (e.g. TF_API_TOKEN) on this repository.
+#   Documentation:
+#     - https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html
+#     - https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets
+#
+# 3. Reference the GitHub secret in step using the `hashicorp/setup-terraform` GitHub Action.
+#   Example:
+#     - name: Setup Terraform
+#       uses: hashicorp/setup-terraform@v1
+#       with:
+#         cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+name: 'Release & deploy'
+
+on:
+  push:
+    branches:
+    - 'main'
+  pull_request:
+
+jobs:
+  terraform-plan:
+    name: 'Terraform plan'
+    runs-on: ubuntu-latest
+    environment: production
+
+    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+    defaults:
+      run:
+        working-directory: terraform
+        shell: bash
+
+    steps:
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    # Setup env variables
+    # - name: Set env
+    #   run: echo "LATEST_RELEASE_SHA256=$(curl -s https://github.com/lipelix/weather-for-humans/archive/refs/tags/latest.tar.gz | openssl sha256)" >> $GITHUB_ENV
+
+    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v1
+      with:
+        cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+    # Since Terraform cloud does not support run variables at this time.
+    # Currently the only to way to pass variables is by creating a `*.auto.tfvars` variables file.
+    - name: Setup Terraform variables
+      id: vars
+      run: |-
+        cat > pipeline.auto.tfvars <<EOF
+        mongodb_atlas_private_key = "${{ secrets.ATLAS_DB_PROJECT_PRIVATE_API_KEY }}"
+        curzy_user_password       = "${{ secrets.MONGODB_USER_PASSWORD }}"
+        tf_api_token              = "${{ secrets.TF_API_TOKEN }}"
+        EOF
+        cat pipeline.auto.tfvars
+
+    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+    - name: Terraform Init
+      run: terraform init
+
+    # Checks that all Terraform configuration files adhere to a canonical format
+    - name: Terraform Format
+      run: terraform fmt -check -diff
+
+    # Generates an execution plan for Terraform
+    - name: Terraform Plan
+      run: terraform plan -input=false
+
+  terraform-apply:
+    name: 'Terraform apply'
+    if: github.ref == 'refs/heads/main'
+    needs: ['terraform-plan']
+    runs-on: ubuntu-latest
+    environment: production
+
+    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+    defaults:
+      run:
+        working-directory: terraform
+        shell: bash
+
+    steps:
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v1
+      with:
+        cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+    # Since Terraform cloud does not support run variables at this time.
+    # Currently the only to way to pass variables is by creating a `*.auto.tfvars` variables file.
+    - name: Setup Terraform variables
+      id: vars
+      run: |-
+        cat > pipeline.auto.tfvars <<EOF
+        mongodb_atlas_private_key = "${{ secrets.ATLAS_DB_PROJECT_PRIVATE_API_KEY }}"
+        curzy_user_password       = "${{ secrets.MONGODB_USER_PASSWORD }}"
+        tf_api_token              = "${{ secrets.TF_API_TOKEN }}"
+        EOF
+
+    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+    - name: Terraform Init
+      run: terraform init
+
+      # On push to "main", build or change infrastructure according to Terraform configuration files
+      # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
+    - name: Terraform Apply
+      run: terraform apply -auto-approve -input=false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,8 @@ jobs:
     - name: Setup Terraform variables
       id: vars
       run: |-
+        pwd
+        ls -la
         cat > pipeline.auto.tfvars <<EOF
         mongodb_atlas_private_key = "${{ secrets.ATLAS_DB_PROJECT_PRIVATE_API_KEY }}"
         curzy_user_password       = "${{ secrets.MONGODB_USER_PASSWORD }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@
 #
 # 2. Generate a Terraform Cloud user API token and store it as a GitHub secret (e.g. TF_API_TOKEN) on this repository.
 #   Documentation:
+#     - find at https://app.terraform.io/app/settings/tokens
 #     - https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html
 #     - https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets
 #
@@ -85,7 +86,6 @@ jobs:
         cat > pipeline.auto.tfvars <<EOF
         mongodb_atlas_private_key = "${{ secrets.ATLAS_DB_PROJECT_PRIVATE_API_KEY }}"
         curzy_user_password       = "${{ secrets.MONGODB_USER_PASSWORD }}"
-        tf_api_token              = "${{ secrets.TF_API_TOKEN }}"
         EOF
         cat pipeline.auto.tfvars
 
@@ -133,7 +133,6 @@ jobs:
         cat > pipeline.auto.tfvars <<EOF
         mongodb_atlas_private_key = "${{ secrets.ATLAS_DB_PROJECT_PRIVATE_API_KEY }}"
         curzy_user_password       = "${{ secrets.MONGODB_USER_PASSWORD }}"
-        tf_api_token              = "${{ secrets.TF_API_TOKEN }}"
         EOF
 
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,17 +43,17 @@
 #       with:
 #         cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
-name: 'Release & deploy'
+name: "Release & deploy"
 
 on:
   push:
     branches:
-    - 'main'
+      - "main"
   pull_request:
 
 jobs:
   terraform-plan:
-    name: 'Terraform plan'
+    name: "Terraform plan"
     runs-on: ubuntu-latest
     environment: production
 
@@ -64,47 +64,43 @@ jobs:
         shell: bash
 
     steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v3
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    # Setup env variables
-    # - name: Set env
-    #   run: echo "LATEST_RELEASE_SHA256=$(curl -s https://github.com/lipelix/weather-for-humans/archive/refs/tags/latest.tar.gz | openssl sha256)" >> $GITHUB_ENV
+      # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
-    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
-      with:
-        cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+      # Since Terraform cloud does not support run variables at this time.
+      # Currently the only to way to pass variables is by creating a `*.auto.tfvars` variables file.
+      - name: Setup Terraform variables
+        id: vars
+        run: |-
+          cat > pipeline.auto.tfvars <<EOF
+          mongodb_atlas_private_key = "${{ secrets.ATLAS_DB_PROJECT_PRIVATE_API_KEY }}"
+          curzy_user_password       = "${{ secrets.MONGODB_USER_PASSWORD }}"
+          EOF
+          cat pipeline.auto.tfvars
 
-    # Since Terraform cloud does not support run variables at this time.
-    # Currently the only to way to pass variables is by creating a `*.auto.tfvars` variables file.
-    - name: Setup Terraform variables
-      id: vars
-      run: |-
-        cat > pipeline.auto.tfvars <<EOF
-        mongodb_atlas_private_key = "${{ secrets.ATLAS_DB_PROJECT_PRIVATE_API_KEY }}"
-        curzy_user_password       = "${{ secrets.MONGODB_USER_PASSWORD }}"
-        EOF
-        cat pipeline.auto.tfvars
+      # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+      - name: Terraform Init
+        run: terraform init
 
-    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-    - name: Terraform Init
-      run: terraform init
+      # Checks that all Terraform configuration files adhere to a canonical format
+      - name: Terraform Format
+        run: terraform fmt -check -diff
 
-    # Checks that all Terraform configuration files adhere to a canonical format
-    - name: Terraform Format
-      run: terraform fmt -check -diff
-
-    # Generates an execution plan for Terraform
-    - name: Terraform Plan
-      run: terraform plan -input=false
+      # Generates an execution plan for Terraform
+      - name: Terraform Plan
+        run: terraform plan -input=false
 
   terraform-apply:
-    name: 'Terraform apply'
+    name: "Terraform apply"
     if: github.ref == 'refs/heads/main'
-    needs: ['terraform-plan']
+    needs: ["terraform-plan"]
     runs-on: ubuntu-latest
     environment: production
 
@@ -115,31 +111,31 @@ jobs:
         shell: bash
 
     steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v3
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
-      with:
-        cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+      # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
-    # Since Terraform cloud does not support run variables at this time.
-    # Currently the only to way to pass variables is by creating a `*.auto.tfvars` variables file.
-    - name: Setup Terraform variables
-      id: vars
-      run: |-
-        cat > pipeline.auto.tfvars <<EOF
-        mongodb_atlas_private_key = "${{ secrets.ATLAS_DB_PROJECT_PRIVATE_API_KEY }}"
-        curzy_user_password       = "${{ secrets.MONGODB_USER_PASSWORD }}"
-        EOF
+      # Since Terraform cloud does not support run variables at this time.
+      # Currently the only to way to pass variables is by creating a `*.auto.tfvars` variables file.
+      - name: Setup Terraform variables
+        id: vars
+        run: |-
+          cat > pipeline.auto.tfvars <<EOF
+          mongodb_atlas_private_key = "${{ secrets.ATLAS_DB_PROJECT_PRIVATE_API_KEY }}"
+          curzy_user_password       = "${{ secrets.MONGODB_USER_PASSWORD }}"
+          EOF
 
-    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-    - name: Terraform Init
-      run: terraform init
+      # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+      - name: Terraform Init
+        run: terraform init
 
-      # On push to "main", build or change infrastructure according to Terraform configuration files
-      # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
-    - name: Terraform Apply
-      run: terraform apply -auto-approve -input=false
+        # On push to "main", build or change infrastructure according to Terraform configuration files
+        # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
+      - name: Terraform Apply
+        run: terraform apply -auto-approve -input=false

--- a/infra/env.auto.tfvars.example
+++ b/infra/env.auto.tfvars.example
@@ -3,4 +3,3 @@
 
 mongodb_atlas_private_key="ATLAS_DB_PROJECT_PRIVATE_API_KEY" // find this at https://cloud.mongodb.com/v2/622e0b3854424113167a31cd#/access/apiKeys
 curzy_user_password="MONGODB_USER_PASSWORD"
-tf_api_token="TF_API_TOKEN" // find at https://app.terraform.io/app/settings/tokens

--- a/infra/init.tf
+++ b/infra/init.tf
@@ -19,11 +19,6 @@ variable "curzy_user_password" {
   sensitive = true
 }
 
-variable "tf_api_token" {
-  type      = string
-  sensitive = true
-}
-
 module "curzy-atlas-mongo-db" {
   source                             = "./atlas-mongo-db"
   mongodb_atlas_cluster_name         = "curzy-production-cluster"

--- a/infra/init.tf
+++ b/infra/init.tf
@@ -31,7 +31,7 @@ module "curzy-atlas-mongo-db" {
   mongodb_atlas_public_key           = "heboyejr"
   mongodb_atlas_cluster_ip_whitelist = yamldecode(file("${path.module}/atlas-mongo-db/ip-whitelist.yaml"))
   mongodb_atlas_cluster_users = {
-    "curzy-user " = {
+    "curzy-user" = {
       name     = "curzy-user",
       password = var.curzy_user_password,
       roles = [


### PR DESCRIPTION
- run `terraform plan` when creating MR
- run `terraform apply` when push (merge) to main

Currently it will create resources in MongoDB Atlas and initialize database cluster.